### PR TITLE
Support Shared Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The app can be configured using the following environment variables:
 
 The App utilizes an advanced version of the auth mechanism known from Eufy. The Anker App employs a two-step authentication scheme: first, keys are exchanged, and second, the full login payload is encrypted. However, it turns out the original Eufy mechanism still works, so we're using that in this project (credits to [eufy-security-client](https://github.com/bropat/eufy-security-client) for inspiration). This might break at some point!
 
-**Note**: Anker currently permits only one simultaneous login at a time. When you log in from another device, all previously generated auth tokens become invalidated. Thus, if you're utilizing this project, you will be unable to use the app concurrently.
+For a "READ-ONLY" access to the data, an account with which the "System" has been shared can be used. By this the main account can still be used in the app to control everything and the shared account can be used for the API access.
+
+**Note**: Anker currently permits only one simultaneous login at a time. When you log in from another device, all previously generated auth tokens become invalidated.
 
 ## Disclaimer
 This project is the result of some work I did to integrate my Solix into my home automation. I no longer own an Anker Solix Solarbank due to disappointment with the product, so this project will not receive any updates. However, I'm happy to accept pull requests.

--- a/src/api.ts
+++ b/src/api.ts
@@ -101,6 +101,10 @@ interface SiteHomepageResponse {
   solarbank_list: Solarbank[],
 }
 
+interface SiteListResponse {
+  site_list: Site[]
+}
+
 export interface UserMqttInfo {
   /**
    * A unique identifier for the user.
@@ -376,6 +380,10 @@ export class SolixApi {
       siteHomepage: async () => {
         const data = {};
         return authFetch<SiteHomepageResponse>("/power_service/v1/site/get_site_homepage", data);
+      },
+      getSiteList: async () => {
+        const data = {};
+        return authFetch<SiteListResponse>("/power_service/v1/site/get_site_list", data);
       },
       getHomeLoadChart: async ({
         siteId,

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,15 @@ async function run(): Promise<void> {
       const siteHomepage = await loggedInApi.siteHomepage();
       let topic = `${config.mqttTopic}/site_homepage`;
       await publisher.publish(topic, siteHomepage.data);
-      for (const site of siteHomepage.data?.site_list ?? []) {
+
+      let sites;
+      if (siteHomepage.data.site_list.length === 0) {
+        // Fallback for Shared Accounts
+        sites = (await loggedInApi.getSiteList()).data.site_list;
+      } else {
+        sites = siteHomepage.data.site_list;
+      }
+      for (const site of sites) {
         const scenInfo = await loggedInApi.scenInfo(site.site_id);
         topic = `${config.mqttTopic}/site/${site.site_name}/scenInfo`;
         await publisher.publish(topic, scenInfo.data);


### PR DESCRIPTION
The change allows to retrieve data with the rights of an shared account.  Due to this the main account can be still used in the app where the shared account is used to the API access. 

As shared accounts have no access to the "Homepage" the topic "site_homepage" does not contain any data. But the topic "site/${site.site_name}/scenInfo" reports the same data as if it would have been used with the main account.

Data changes are not possible with a shared account.

Fixes #8 